### PR TITLE
Fix the canonical URLs

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+yarn install
+yarn build
+
+dist_dir='.vitepress/dist'
+
+for name in README LICENSE CONTRIBUTING; do
+  rm "$dist_dir/$name.html"
+done
+
+for name in about legal; do
+  mkdir -p "$dist_dir/$name"
+  cp "$dist_dir/$name.html" "$dist_dir/$name/index.html"
+done
+
+for article_path in $(find "$dist_dir/articles" -name '*.html'); do
+  name_without_extension="${article_path%.*}"
+  mkdir -p "$name_without_extension"
+  cp "$article_path" "$name_without_extension/index.html"
+done

--- a/template.yml
+++ b/template.yml
@@ -54,8 +54,7 @@ Resources:
             build:
               commands:
                 - nvm use 20
-                - yarn install
-                - yarn build
+                - ./bin/build
           artifacts:
             baseDirectory: .vitepress/dist
             files:


### PR DESCRIPTION
In the old site, `/articles/xyz/` was the canonical URL, but in the new only `/articles/xyz` (without slash at the end) works. I haven't been able to figure out how to make a redirect for it. All search engines have the URLs with a slash at the end, and traffic has plummeted since the new site was launched.

This new build script makes a copy of every article to `/articles/xyz/index.html`, which seems to make `/articles/xyz/` work again. I don't know if this is a viable long term solution.

I also noticed that README, LICENSE, and CONTRIBUTING were made into pages, that was never the intention, so this also removes them from the build.