### PR TITLE
Move the build and header config into the repo

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,7 +1,6 @@
 version: 1
 env:
   variables:
-    BASE_URL: https://athena.guide
     _CUSTOM_IMAGE: amplify:al2023
     _BUILD_TIMEOUT: 5
     AMPLIFY_SKIP_BACKEND_BUILD: true

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,4 +1,10 @@
 version: 1
+env:
+  variables:
+    BASE_URL: https://athena.guide
+    _CUSTOM_IMAGE: amplify:al2023
+    _BUILD_TIMEOUT: 5
+    AMPLIFY_SKIP_BACKEND_BUILD: true
 frontend:
   phases:
     build:

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,14 @@
+version: 1
+frontend:
+  phases:
+    build:
+      commands:
+        - nvm use 20
+        - ./bin/build
+  artifacts:
+    baseDirectory: .vitepress/dist
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,11 @@
+customHeaders:
+  - pattern: '**/*'
+    headers:
+      - key: Strict-Transport-Security
+        value: max-age=31536000; includeSubDomains
+      - key: X-Frame-Options
+        value: SAMEORIGIN
+      - key: X-XSS-Protection
+        value: 1; mode=block
+      - key: X-Content-Type-Options
+        value: nosniff

--- a/template.yml
+++ b/template.yml
@@ -38,15 +38,6 @@ Resources:
       IAMServiceRole: !GetAtt AmplifyRole.Arn
       Repository: !Ref GitHubRepositoryUrl
       OauthToken: !Ref GitHubToken
-      EnvironmentVariables:
-        - Name: BASE_URL
-          Value: https://athena.guide
-        - Name: _CUSTOM_IMAGE
-          Value: amplify:al2023
-        - Name: _BUILD_TIMEOUT
-          Value: 5
-        - Name: AMPLIFY_SKIP_BACKEND_BUILD
-          Value: true
 
   AmplifyBranch:
     Type: AWS::Amplify::Branch

--- a/template.yml
+++ b/template.yml
@@ -47,32 +47,6 @@ Resources:
           Value: 5
         - Name: AMPLIFY_SKIP_BACKEND_BUILD
           Value: true
-      BuildSpec: |-
-        version: 1
-        frontend:
-          phases:
-            build:
-              commands:
-                - nvm use 20
-                - ./bin/build
-          artifacts:
-            baseDirectory: .vitepress/dist
-            files:
-              - '**/*'
-          customHeaders:
-            - pattern: '**/*'
-              headers:
-                - key: Strict-Transport-Security
-                  value: max-age=31536000; includeSubDomains
-                - key: X-Frame-Options
-                  value: SAMEORIGIN
-                - key: X-XSS-Protection
-                  value: 1; mode=block
-                - key: X-Content-Type-Options
-                  value: nosniff
-          cache:
-            paths:
-              - node_modules/**/*
 
   AmplifyBranch:
     Type: AWS::Amplify::Branch


### PR DESCRIPTION
The docs say specifying headers in the build spec is deprecated, and using the template for the build spec means that it's the same for prod and staging, which is inconvenient sometimes.